### PR TITLE
Add informative error when GAIA_TOOLS_DATA envar is not set

### DIFF
--- a/gaia_tools/load/path.py
+++ b/gaia_tools/load/path.py
@@ -4,7 +4,9 @@ _GAIA_TOOLS_DATA= os.getenv('GAIA_TOOLS_DATA')
 if _GAIA_TOOLS_DATA is None:
     raise RuntimeError(
         'Environment variable `GAIA_TOOLS_DATA` is not set. '
-        'This is required to define where the Gaia data are downloaded to.'
+        'This is required to define where the Gaia data are downloaded to. '
+        'See the readme: https://github.com/jobovy/gaia_tools#data-files-and-environment-variables '
+        'for more information.'
     )
 
 def apogeePath(dr=13):

--- a/gaia_tools/load/path.py
+++ b/gaia_tools/load/path.py
@@ -1,5 +1,12 @@
 import os, os.path
+
 _GAIA_TOOLS_DATA= os.getenv('GAIA_TOOLS_DATA')
+if _GAIA_TOOLS_DATA is None:
+    raise RuntimeError(
+        'Environment variable `GAIA_TOOLS_DATA` is not set. '
+        'This is required to define where the Gaia data are downloaded to.'
+    )
+
 def apogeePath(dr=13):
     if dr == 12:
         return os.path.join(_GAIA_TOOLS_DATA,'apogee','DR%i' % dr,


### PR DESCRIPTION
When running the code from the readme, I skipped over setting this environment variable. To give some help to similar users who do not read things, raise a runtime error if this variable is set to give some pointers.
