### PR TITLE
fix fp128 issue on windows, fix readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -469,7 +469,7 @@ RECIPES
 Match APOGEE or APOGEE-RC to Gaia DR2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We can do this with the `CDS xMatch Service <http://cdsxmatch.u-strasbg.fr/>`__ using the ``gaia_tools.xmatch.cds`` routine:
+We can do this with the `CDS xMatch Service <http://cdsxmatch.u-strasbg.fr/>`__ using the ``gaia_tools.xmatch.cds`` routine::
 
     apogee_cat= gaia_tools.load.apogee()
     gaia2_matches, matches_indx= gaia_tools.xmatch.cds(apogee_cat,xcat='vizier:I/345/gaia2')

--- a/gaia_tools/xmatch/__init__.py
+++ b/gaia_tools/xmatch/__init__.py
@@ -189,25 +189,19 @@ def cds_load(filename):
         # windows do not have float128, but source_id is double
         # get around this by squeezing precision from int64 on source_id as source_id is always integer anyway
         # first read everything as fp64 and then convert source_id to int64 will keep its precision
-        with open(filename, 'r'):
-            # only read the first row max to reduce workload to just get the column name
-            data = numpy.genfromtxt(filename, delimiter=',', skip_header=0,
-                                    filling_values=-9999.99, names=True, max_rows=1,
-                                    dtype='float64')
-            to_list = list(data.dtype.names)
-            # construct a list where everything is fp64 except 'source_id' being int64
-            dtype_list = [('{}'.format(i), numpy.float64) for i in to_list]
-            # find the index of source_id in list
-            idx = 0
-            for name in dtype_list:
-                if 'source_id' in name: break
-                idx += 1
-            dtype_list[idx] = ('source_id', numpy.uint64)
+        data = numpy.genfromtxt(filename, delimiter=',', skip_header=0,
+                                filling_values=-9999.99, names=True, max_rows=1,
+                                dtype='float64')  # only read the first row max to reduce workload to just get the column name
+        to_list = list(data.dtype.names)
+        # construct a list where everything is fp64 except 'source_id' being int64
+        dtype_list = [('{}'.format(i), numpy.float64) for i in to_list]
+        dtype_list[dtype_list.index(('source_id', numpy.float64))] = ('source_id', numpy.uint64)
 
-            data = numpy.genfromtxt(filename, delimiter=',', skip_header=0,
-                                    filling_values=-9999.99, names=True,
-                                    dtype=dtype_list)
-        return data
+        print(dtype_list)
+
+        return numpy.genfromtxt(filename, delimiter=',', skip_header=0,
+                                filling_values=-9999.99, names=True,
+                                dtype=dtype_list)
     else:
         return numpy.genfromtxt(filename, delimiter=',', skip_header=0,
                                 filling_values=-9999.99, names=True,

--- a/gaia_tools/xmatch/__init__.py
+++ b/gaia_tools/xmatch/__init__.py
@@ -1,11 +1,13 @@
 # Tools for cross-matching catalogs
-import os, os.path
 import csv
+import os
+import os.path
+import platform
 import shutil
+import subprocess
 import tempfile
 import warnings
-import subprocess
-import platform
+
 WIN32= platform.system() == 'Windows'
 import numpy
 import astropy.coordinates as acoords
@@ -187,17 +189,28 @@ def cds_load(filename):
         # windows do not have float128, but source_id is double
         # get around this by squeezing precision from int64 on source_id as source_id is always integer anyway
         # first read everything as fp64 and then convert source_id to int64 will keep its precision
-        data = numpy.genfromtxt(filename,delimiter=',',skip_header=0,
-                                filling_values=-9999.99,names=True,
-                                dtype='float64')
-        to_list = list(data.dtype.names)
-        to_list.remove('source_id')
-        # construct a list where everything is fp64 except 'source_id' being int64
-        dtype = [('{}'.format(i), numpy.float64) for i in to_list] + [('source_id', numpy.int64)]
-        return data.astype(dtype)
+        with open(filename, 'r'):
+            # only read the first row max to reduce workload to just get the column name
+            data = numpy.genfromtxt(filename, delimiter=',', skip_header=0,
+                                    filling_values=-9999.99, names=True, max_rows=1,
+                                    dtype='float64')
+            to_list = list(data.dtype.names)
+            # construct a list where everything is fp64 except 'source_id' being int64
+            dtype_list = [('{}'.format(i), numpy.float64) for i in to_list]
+            # find the index of source_id in list
+            idx = 0
+            for name in dtype_list:
+                if 'source_id' in name: break
+                idx += 1
+            dtype_list[idx] = ('source_id', numpy.uint64)
+
+            data = numpy.genfromtxt(filename, delimiter=',', skip_header=0,
+                                    filling_values=-9999.99, names=True,
+                                    dtype=dtype_list)
+        return data
     else:
-        return numpy.genfromtxt(filename,delimiter=',',skip_header=0,
-                                filling_values=-9999.99,names=True,
+        return numpy.genfromtxt(filename, delimiter=',', skip_header=0,
+                                filling_values=-9999.99, names=True,
                                 dtype='float128')
 
 def cds_matchback(cat,xcat,colRA='RA',colDec='DEC',selection='best',

--- a/gaia_tools/xmatch/__init__.py
+++ b/gaia_tools/xmatch/__init__.py
@@ -197,8 +197,6 @@ def cds_load(filename):
         dtype_list = [('{}'.format(i), numpy.float64) for i in to_list]
         dtype_list[dtype_list.index(('source_id', numpy.float64))] = ('source_id', numpy.uint64)
 
-        print(dtype_list)
-
         return numpy.genfromtxt(filename, delimiter=',', skip_header=0,
                                 filling_values=-9999.99, names=True,
                                 dtype=dtype_list)


### PR DESCRIPTION
This PR fixed the np.float128 is not a thing on windows.
Get around this by squeezing precision from int64 on source_id as source_id is always integer anyway first read everything as fp64 and then convert source_id to int64 will keep its precision.

Here are some test on windows numpy precision with a sample Gaia DR2 source_id:
`np.float64(431594980053422000) + 1 == np.int64(431594980053422000)` is `True` due to lack of precision
`np.int64(431594980053422000) + 1 == np.int64(431594980053422000)` is `False` due to enough precision

One concern is whether numpy will preserve the precision when you first read the ID in fp64 and then convert it to int64 which is what this PR did, and it seems the precision does preserve
`np.array(np.float64(431594980053422000), dtype=np.int64) + 1 == np.int64(431594980053422000)` is `False`