### PR TITLE
add additional matching to xmatch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -205,24 +205,27 @@ cross-match the APOGEE-RC data and TGAS do::
 	    aprc= aprc[m1]
 	    tgas= tgas[m2]
 
-If your catalogs contain multiple telescope/observer and you want to do cross-matching with additional matching to
-those telescopes/observer, you can do it by specifying ``col_field`` and here is an example to demonstrate the usage::
+If your catalogs contain duplicates that differ in another property
+and you want to match on both position and the other property, you can
+match both by specifying ``col_field``. An example use case is for
+APOGEE DR16 which contains stars that are observed by two different
+telescopes (the APO 2.5m in the northern hemisphere and the LCO 2.5m
+in the southern hemisphere). An example to
+demonstrate the usage::
 
-        from gaia_tools import xmatch  # use xmatch_v2 branch
+        from gaia_tools import xmatch
+	# Create simple example data catalogs
         from astropy.table import QTable
-
         mc1 = {'RA': [10, 10, 30, 10, 10], 'DEC': [10, 10, 30, 10, 10], 'LENS': ['A', 'B', 'A', 'C', 'A']}
         mc2 = {'RA': [10, 20, 10, 20, 30], 'DEC': [10, 20, 10, 20, 30], 'LENS': ['A', 'A', 'B', 'B', 'A']}
-
         cat1 = QTable()
         for key in mc1.keys():
             cat1[key] = mc1[key]
-
         cat2 = QTable()
         for key in mc2.keys():
             cat2[key] = mc2[key]
-
-        idx1, idx2, sep = xmatch.xmatch(cat1, cat2, col_field='LENS')
+	# Match mc1 and mc2 on (RA,Dec) and LENS
+        idx1, idx2, sep = xmatch.xmatch(cat1,cat2,col_field='LENS')
         # array([0, 1, 2, 4])
         print(idx2)
         # array([0, 2, 4, 0])

--- a/README.rst
+++ b/README.rst
@@ -208,10 +208,10 @@ cross-match the APOGEE-RC data and TGAS do::
 If your catalogs contain multiple telescope/observer and you want to do cross-matching with additional matching to
 those telescopes/observer, you can do it by specifying ``col_field`` and here is an example to demonstrate the usage::
 
-        from gaia_tools import xmatch
+        from gaia_tools import xmatch  # use xmatch_v2 branch
         from astropy.table import QTable
 
-        mc1 = {'RA': [10, 10, 30, 10], 'DEC': [10, 10, 30, 10], 'LENS': ['A', 'B', 'A', 'A']}
+        mc1 = {'RA': [10, 10, 30, 10, 10], 'DEC': [10, 10, 30, 10, 10], 'LENS': ['A', 'B', 'A', 'C', 'A']}
         mc2 = {'RA': [10, 20, 10, 20, 30], 'DEC': [10, 20, 10, 20, 30], 'LENS': ['A', 'A', 'B', 'B', 'A']}
 
         cat1 = QTable()
@@ -223,8 +223,7 @@ those telescopes/observer, you can do it by specifying ``col_field`` and here is
             cat2[key] = mc2[key]
 
         idx1, idx2, sep = xmatch.xmatch(cat1, cat2, col_field='LENS')
-        print(idx1)
-        # array([0, 1, 2, 3])
+        # array([0, 1, 2, 4])
         print(idx2)
         # array([0, 2, 4, 0])
 

--- a/README.rst
+++ b/README.rst
@@ -205,6 +205,28 @@ cross-match the APOGEE-RC data and TGAS do::
 	    aprc= aprc[m1]
 	    tgas= tgas[m2]
 
+If your catalogs contain multiple telescope/observer and you want to do cross-matching with additional matching to
+those telescopes/observer, you can do it by specifying ``col_field`` and here is an example to demonstrate the usage::
+
+        from gaia_tools import xmatch
+        from astropy.table import QTable
+
+        mc1 = {'RA': [10, 10, 30, 10], 'DEC': [10, 10, 30, 10], 'LENS': ['A', 'B', 'A', 'A']}
+        mc2 = {'RA': [10, 20, 10, 20, 30], 'DEC': [10, 20, 10, 20, 30], 'LENS': ['A', 'A', 'B', 'B', 'A']}
+
+        cat1 = QTable()
+        for key in mc1.keys():
+            cat1[key] = mc1[key]
+
+        cat2 = QTable()
+        for key in mc2.keys():
+            cat2[key] = mc2[key]
+
+        idx1, idx2, sep = xmatch.xmatch(cat1, cat2, col_field='LENS')
+        print(idx1)
+        # array([0, 1, 2, 3])
+        print(idx2)
+        # array([0, 2, 4, 0])
 
 Further, it is possible to cross-match any catalog to the catalogs in
 the CDS database using the `CDS cross-matching service

--- a/gaia_tools/xmatch/__init__.py
+++ b/gaia_tools/xmatch/__init__.py
@@ -40,7 +40,7 @@ def xmatch(cat1,cat2,maxdist=2,
        colpmRA2= ('pmra') name of the tag in cat2 with the proper motion in right ascension in degree in cat2 (assumed to be ICRS; includes cos(Dec)) [only used when epochs are different]
        colpmDec2= ('pmdec') name of the tag in cat2 with the proper motion in declination in degree in cat2 (assumed to be ICRS) [only used when epochs are different]
        swap= (False) if False, find closest matches in cat2 for each cat1 source, if False do the opposite (important when one of the catalogs has duplicates)
-       col_field= (None) if None, simply do cross-matching, if a string, then do cross-match with additional matching in that catagory
+       col_field= (None) if None, simply cross-match on RA and Dec; if a string, then cross-match on RA and Dec with additional matching in the data tag specified by the string
     OUTPUT:
        (index into cat1 of matching objects,
         index into cat2 of matching objects,

--- a/gaia_tools/xmatch/__init__.py
+++ b/gaia_tools/xmatch/__init__.py
@@ -90,9 +90,11 @@ def xmatch(cat1,cat2,maxdist=2,
             d2d = numpy.ones(len(cat1)) * 1000.  # times 1000 to debug
             idx = numpy.zeros(len(cat1), dtype=int)
 
-        for unique in uniques:
+        for unique in uniques:  # loop over the class
             idx_1 = numpy.arange(cat1[colRA1].shape[0])[cat1[col_field] == unique]
             idx_2 = numpy.arange(cat2[colRA2].shape[0])[cat2[col_field] == unique]
+            if idx_1.shape[0] == 0 or idx_2.shape[0] == 0:  # the case where a class only exists in one but not the other
+                continue
 
             if swap:
                 temp_idx, temp_d2d, d3d = mc2[idx_2].match_to_catalog_sky(mc1[idx_1])
@@ -104,6 +106,8 @@ def xmatch(cat1,cat2,maxdist=2,
                 m1 = numpy.arange(len(cat1))
                 idx[cat1[col_field] == unique] = idx_2[temp_idx]
                 d2d[cat1[col_field] == unique] = temp_d2d
+
+        d2d = d2d * temp_d2d.unit  # make sure finally we have an unit on d2d array s.t. "<" operation can complete
 
     else:
         if swap:

--- a/gaia_tools/xmatch/__init__.py
+++ b/gaia_tools/xmatch/__init__.py
@@ -83,11 +83,11 @@ def xmatch(cat1,cat2,maxdist=2,
             raise KeyError("'%s' does not exist in both catalog" % col_field)
 
         uniques = numpy.unique(cat1[col_field])
-        if swap:
-            d2d = numpy.ones(len(cat2)) * 1000.  # times 1000 to debug
+        if swap:  # times neg one to indicate those indices untouch will be noticed at the end and filtered out
+            d2d = numpy.ones(len(cat2)) * -1.
             idx = numpy.zeros(len(cat2), dtype=int)
         else:
-            d2d = numpy.ones(len(cat1)) * 1000.  # times 1000 to debug
+            d2d = numpy.ones(len(cat1)) * -1.
             idx = numpy.zeros(len(cat1), dtype=int)
 
         for unique in uniques:  # loop over the class
@@ -117,7 +117,8 @@ def xmatch(cat1,cat2,maxdist=2,
             idx,d2d,d3d = mc1.match_to_catalog_sky(mc2)
             m1= numpy.arange(len(cat1))
 
-    mindx= d2d < maxdist*u.arcsec
+    # to make sure filtering out all neg ones which are untouched
+    mindx= ((d2d < maxdist*u.arcsec) & (0.*u.arcsec <= d2d))
     m1= m1[mindx]
     m2= idx[mindx]
     if swap:


### PR DESCRIPTION
this is an issue I came across when I try to row matching the beta DR16 and the final DR16 and found that I have to deal with the overlaps because I only want to match apo25m to apo25m and lco25m to lco25m and same for apo1m

So I added a functionality to do that, letting user to specify an additional field to cross-match, should be useful

here is a short piece of code to demo
```
from gaia_tools import xmatch  # use xmatch_v2 branch
from astropy.table import QTable

mc1 = {'RA': [10, 10, 30, 10, 10], 'DEC': [10, 10, 30, 10, 10], 'LENS': ['A', 'B', 'A', 'C', 'A']}
mc2 = {'RA': [10, 20, 10, 20, 30], 'DEC': [10, 20, 10, 20, 30], 'LENS': ['A', 'A', 'B', 'B', 'A']}

cat1 = QTable()
for key in mc1.keys():
    cat1[key] = mc1[key]

cat2 = QTable()
for key in mc2.keys():
    cat2[key] = mc2[key]
    
idx1, idx2, sep = xmatch.xmatch(cat1, cat2, col_field='LENS')
print(idx1)
# array([0, 1, 2, 4])
print(idx2)
# array([0, 2, 4, 0])

```