### PR TITLE
Add functions to load Gaia DR3 RVS and XP sampled spectra

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -255,6 +255,34 @@ returned by CDS is returned instead.
 If you want to download a catalog from CDS, you can use
 ``gaia_tools.load.download.vizier``.
 
+Reading RVS or XP spectra
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+here is a sample usage for a single stars
+.. code-block:: python
+
+    from gaia_tools.load.spec import load_rvs_spec, load_xp_sampled_spec
+
+    # load Gaia DR3 2771993642553377280 xp spectrum
+    wavelength, flux, flux_err = load_xp_sampled_spec(2771993642553377280)
+
+    # load Gaia DR3 2771993642553377280 rvsspectrum
+    wavelength, flux, flux_err = load_rvs_spec(2771993642553377280)
+
+
+You can also supply a list of source id
+.. code-block:: python
+
+    from gaia_tools.load.spec import load_rvs_spec, load_xp_sampled_spec
+
+    # load Gaia DR3 2771993642553377280 and 383167952467292288
+    wavelength, flux, flux_err = load_xp_sampled_spec([2771993642553377280, 383167952467292288])
+
+    # also support loading a list of source id with duplicated entries (e.g. from APOGEE allstar some are duplicated)
+    wavelength, flux, flux_err = load_xp_sampled_spec([2771993642553377280, 383167952467292288, 2771993642553377280])
+
+    # also support loading a list of source id with some stars not having corresponding spectra, returning zero array for that star with warnings
+    wavelength, flux, flux_err = load_xp_sampled_spec([2771993642553377280, 1234567891234567891])
+
 Tools for querying the Gaia Archive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -257,8 +257,7 @@ If you want to download a catalog from CDS, you can use
 
 Reading RVS or XP spectra
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-here is a sample usage for a single stars
-.. code-block:: python
+To read Gaia RVS or XP spectra, here is a sample usage for a single stars::
 
     from gaia_tools.load.spec import load_rvs_spec, load_xp_sampled_spec
 
@@ -269,8 +268,7 @@ here is a sample usage for a single stars
     wavelength, flux, flux_err = load_rvs_spec(2771993642553377280)
 
 
-You can also supply a list of source id
-.. code-block:: python
+You can also supply a list of source id::
 
     from gaia_tools.load.spec import load_rvs_spec, load_xp_sampled_spec
 

--- a/README.rst
+++ b/README.rst
@@ -256,8 +256,9 @@ If you want to download a catalog from CDS, you can use
 ``gaia_tools.load.download.vizier``.
 
 Reading RVS or XP spectra
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To read Gaia RVS or XP spectra, here is a sample usage for a single stars::
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To read the Gaia RVS or sampled XP spectra released in DR3, here is an example for a single star::
 
     from gaia_tools.load.spec import load_rvs_spec, load_xp_sampled_spec
 
@@ -268,7 +269,7 @@ To read Gaia RVS or XP spectra, here is a sample usage for a single stars::
     wavelength, flux, flux_err = load_rvs_spec(2771993642553377280)
 
 
-You can also supply a list of source id::
+You can also supply a list of source ids::
 
     from gaia_tools.load.spec import load_rvs_spec, load_xp_sampled_spec
 
@@ -281,6 +282,8 @@ You can also supply a list of source id::
     # also support loading a list of source id with some stars not having corresponding spectra, returning zero array for that star with warnings
     wavelength, flux, flux_err = load_xp_sampled_spec([2771993642553377280, 1234567891234567891])
 
+These functions assume that you have downloaded the RVS/XP spectra to ``$GAIA_TOOLS_DATA/Gaia/gdr3/Spectroscopy`` in their respective folders (mirroring the Gaia Archive). Automagic downloading of these spectra is currently not supported.
+    
 Tools for querying the Gaia Archive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/gaia_tools/load/spec.py
+++ b/gaia_tools/load/spec.py
@@ -83,7 +83,7 @@ def read_spec_internal(source_ids, assume_unique, base_path, wavelength_grid):
             first_occurence_idx = np.argmax(source_ids == source_ids[i])
             all_spec[i] = all_spec[first_occurence_idx]
             all_spec_error[i] = all_spec_error[first_occurence_idx]
-            not_found[i] = False
+            not_found[i] = not_found[first_occurence_idx]
             
     if np.any(not_found):
         warnings.warn(f"These source id have no corresponding spectra found: {source_ids[not_found]}")

--- a/gaia_tools/load/spec.py
+++ b/gaia_tools/load/spec.py
@@ -2,7 +2,6 @@ import os
 import glob
 import tqdm
 import numpy as np
-import pandas as pd
 from astropy.io import ascii
 from itertools import compress
 import warnings
@@ -106,7 +105,7 @@ def load_rvs_spec(source_ids, assume_unique=False):
         2022-06-16 - Written - Henry Leung (UofT)
     """
     base_path = os.path.join(
-        _GAIA_TOOLS_DATA, "Gaia/gdr3/Spectroscopy/rvs_mean_spectrum/"
+        _GAIA_TOOLS_DATA, "Gaia","gdr3","Spectroscopy","rvs_mean_spectrum"
     )
     wavelength_grid = np.arange(846, 870.01, 0.01)
     return read_spec_internal(
@@ -132,7 +131,7 @@ def load_xp_sampled_spec(source_ids, assume_unique=False):
         2022-06-16 - Written - Henry Leung (UofT)
     """
     base_path = os.path.join(
-        _GAIA_TOOLS_DATA, "Gaia/gdr3/Spectroscopy/xp_sampled_mean_spectrum/"
+        _GAIA_TOOLS_DATA, "Gaia","gdr3","Spectroscopy","xp_sampled_mean_spectrum"
     )        
     wavelength_grid = np.arange(336.0, 1022.0, 2.0)
     return read_spec_internal(

--- a/gaia_tools/load/spec.py
+++ b/gaia_tools/load/spec.py
@@ -67,10 +67,11 @@ def read_spec_internal(source_ids, assume_unique, base_path, wavelength_grid):
                 assume_unique=False,
                 return_indices=True,
             )
-            current_idx = np.where(combo_comparisons[:, idx])[0][idx1]
-            all_spec[current_idx] = np.vstack(spec_f["flux"][idx2])
-            all_spec_error[current_idx] = np.vstack(spec_f["flux_error"][idx2])
-            not_found[current_idx] = False
+            if len(matches) > 0:
+                current_idx = np.where(combo_comparisons[:, idx])[0][idx1]
+                all_spec[current_idx] = np.vstack(spec_f["flux"][idx2])
+                all_spec_error[current_idx] = np.vstack(spec_f["flux_error"][idx2])
+                not_found[current_idx] = False
 
     # deal with duplicated source_id
     if not assume_unique:

--- a/gaia_tools/load/spec.py
+++ b/gaia_tools/load/spec.py
@@ -1,0 +1,142 @@
+import os
+import glob
+import tqdm
+import numpy as np
+import pandas as pd
+from astropy.io import ascii
+from itertools import compress
+import warnings
+
+from .path import _GAIA_TOOLS_DATA
+
+
+def read_spec_internal(source_ids, assume_unique, base_path, wavelength_grid):
+    """
+    internal function to read spectra based on a list of source id
+    """
+    file_paths = glob.glob(os.path.join(base_path, "*.csv.gz"))
+    if len(file_paths) == 0:
+        raise FileNotFoundError(f"Gaia data does not exist at {base_path}")
+    file_names = [os.path.basename(x) for x in file_paths]
+
+    source_ids = np.atleast_1d(source_ids)
+    # HEALpix level 8: 8796093022208
+    reduced_source_ids = source_ids // 8796093022208
+    num_source = len(reduced_source_ids)
+
+    all_spec = np.zeros([num_source, len(wavelength_grid)], dtype=np.float32)
+    all_spec_error = np.zeros([num_source, len(wavelength_grid)], dtype=np.float32)
+    not_found = np.ones(num_source, dtype=bool)
+    
+    # Extract HEALPix level-8 from file name
+    healpix_8_min = [
+        int(file[file.find("_") + 1 : file.rfind("-")]) for file in file_names
+    ]
+    healpix_8_max = [
+        int(file[file.rfind("-") + 1 : file.rfind(".csv")]) for file in file_names
+    ]
+    reference_file = {
+        "file": file_names,
+        "healpix8_min": healpix_8_min,
+        "healpix8_max": healpix_8_max,
+    }
+
+    combo_comparisons = np.asarray(
+        [
+            (reference_file["healpix8_min"] <= i)
+            & (i <= reference_file["healpix8_max"])
+            for i in reduced_source_ids
+        ]
+    )
+    files_required = np.unique(
+        [list(compress(file_names, i)) for i in combo_comparisons]
+    )
+
+    if not np.all(np.any(combo_comparisons, axis=1)):
+        raise ValueError("Contain invalid Gaia source id")
+
+    for idx, i in enumerate(tqdm.tqdm(file_names, desc="Working on data file:")):
+        if not i in files_required:
+            continue
+        else:
+            spec_f = ascii.read(os.path.join(base_path, i))
+            current_source_ids = source_ids[combo_comparisons[:, idx]]
+            matches, idx1, idx2 = np.intersect1d(
+                current_source_ids,
+                spec_f["source_id"].data,
+                assume_unique=False,
+                return_indices=True,
+            )
+            current_idx = np.where(combo_comparisons[:, idx])[0][idx1]
+            all_spec[current_idx] = np.vstack(spec_f["flux"][idx2])
+            all_spec_error[current_idx] = np.vstack(spec_f["flux_error"][idx2])
+            not_found[current_idx] = False
+
+    # deal with duplicated source_id
+    if not assume_unique:
+        uniques = np.unique(source_ids, return_index=True)[1]
+        result = np.ones_like(source_ids, dtype=bool)
+        result[uniques] = False
+        duplicated_idx = np.where(result)[0]
+        for i in duplicated_idx:
+            first_occurence_idx = np.argmax(source_ids == source_ids[i])
+            all_spec[i] = all_spec[first_occurence_idx]
+            all_spec_error[i] = all_spec_error[first_occurence_idx]
+            not_found[i] = False
+            
+    if np.any(not_found):
+        warnings.warn(f"These source id have no corresponding spectra found: {source_ids[not_found]}")
+
+    return wavelength_grid, all_spec, all_spec_error
+
+
+def load_rvs_spec(source_ids, assume_unique=False):
+    """
+    NAME:
+        load_rvs_spec
+    PURPOSE:
+        Read corresponding RVS spectra for a list of source id
+    INPUT:
+        source_ids (int, list, ndarray): source id
+        assume_unique (bool): whether to assume the list of source id is unique
+    OUTPUT:
+        wavelength grid, RVS spectra flux row matched to source_id, RVS spectra corresponding flux uncertainty
+    HISTORY:
+        2022-06-16 - Written - Henry Leung (UofT)
+    """
+    base_path = os.path.join(
+        _GAIA_TOOLS_DATA, "Gaia/gdr3/Spectroscopy/rvs_mean_spectrum/"
+    )
+    wavelength_grid = np.arange(846, 870.01, 0.01)
+    return read_spec_internal(
+        source_ids=source_ids,
+        assume_unique=assume_unique,
+        base_path=base_path,
+        wavelength_grid=wavelength_grid,
+    )
+
+
+def load_xp_sampled_spec(source_ids, assume_unique=False):
+    """
+    NAME:
+        load_xp_sampled_spec
+    PURPOSE:
+        Read corresponding XP spectra for a list of source id
+    INPUT:
+        source_ids (int, list, ndarray): source id
+        assume_unique (bool): whether to assume the list of source id is unique
+    OUTPUT:
+        wavelength grid, XP spectra flux row matched to source_id, XP spectra corresponding flux uncertainty
+    HISTORY:
+        2022-06-16 - Written - Henry Leung (UofT)
+    """
+    base_path = os.path.join(
+        _GAIA_TOOLS_DATA, "Gaia/gdr3/Spectroscopy/xp_sampled_mean_spectrum/"
+    )        
+    wavelength_grid = np.arange(336.0, 1022.0, 2.0)
+    return read_spec_internal(
+        source_ids=source_ids,
+        assume_unique=assume_unique,
+        base_path=base_path,
+        wavelength_grid=wavelength_grid,
+    )


### PR DESCRIPTION
This PR adds functions to load Gaia DR3 RVS and XP sampled spectra

Outstanding questions:
- Do you want to add function to download the `*.csv.gz` or assume users have them.
- Do you want to add a quick lookup function if users just want to quickly obtain spectrum of a single star by downloading fits file for those individual star, load them as temporary file to extract and return the spectrum. Not sure if it will be useful tho.
- Do you want to add an option that also load GSP-Phot parameters if a user use `load_xp_sampled_spec` and same for GSP-Spec for `load_rvs_spec` like APOGEE tool does. This will be more difficult tho as we also need the main table and astrophysical parameters table to do that.

So far here is a sample usage for a single stars
```python
from gaia_tools.load.spec import load_rvs_spec, load_xp_sampled_spec

# load Gaia DR3 2771993642553377280 xp spectrum
wavelength, flux, flux_err = load_xp_sampled_spec(2771993642553377280)

# load Gaia DR3 2771993642553377280 rvsspectrum
wavelength, flux, flux_err = load_rvs_spec(2771993642553377280)
```

You can also supply a list of source id
```python
from gaia_tools.load.spec import load_rvs_spec, load_xp_sampled_spec

# load Gaia DR3 2771993642553377280 and 383167952467292288
wavelength, flux, flux_err = load_xp_sampled_spec([2771993642553377280, 383167952467292288])

# also support loading a list of source id with duplicated entries (e.g. from APOGEE allstar some are duplicated)
wavelength, flux, flux_err = load_xp_sampled_spec([2771993642553377280, 383167952467292288, 2771993642553377280])

# also support loading a list of source id with some stars not having corresponding spectra, returning zero array for that star with warnings
wavelength, flux, flux_err = load_xp_sampled_spec([2771993642553377280, 1234567891234567891])
```

On your computing server, you can also test real world use case, loading the first 10 entries in APOGEE DR17 allstar
```python
import numpy as np
from astropy.io import fits
from gaia_tools.load.spec import load_rvs_spec

# new Gaia DR3 all columns cross-matches to APOGEE DR17
gaia_columns = fits.getdata("/epsen_data/scr/henrysky/github/astroNN_APOGEE_VAC_2/apogeedr17_syncspec_gaiadr3_xmatch.fits")[1:11]

wavelength, flux, flux_err = load_rvs_spec(gaia_columns["source_id"])

# to confirm in warning message some of the source id do not have corresponding spectra
no_rvs_idx_officially = ~np.asarray(gaia_columns["HAS_RVS"], dtype=bool)
print("List of soruce id Gaia officially indicate no RVS spectra:", (gaia_columns["source_id"])[no_rvs_idx_officially])

# all their returned spectra are zero if no corresponding spectra, confirm all zeros
print("Sum of all spectra flux: ", np.sum(flux[no_rvs_idx_officially]))
```